### PR TITLE
fix build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .cache
 dist
 
+# Editor files
+.vscode
+
 # Node dependencies
 node_modules
 


### PR DESCRIPTION
Closes #6 

With this changes its now possible to build and run the storybook on Vercel (and for sure on a Node server)

- refactor: await for nuxt build process before resolving the viteConfig
- fix: Disable dev mode inside loadNuxt to prevent running subtasks in the build process

**How to test**
- Add it to your nuxt project
- Run the build storybook command
- Run `vercel dev` with the vercel cli to test the build and the output as it would be if you deploy it on vercel for production
- Check if everything is running
