### PR TITLE
fix: vite vue plugin order

### DIFF
--- a/packages/storybook-nuxt/src/preset.ts
+++ b/packages/storybook-nuxt/src/preset.ts
@@ -53,7 +53,6 @@ async function defineNuxtConfig(baseConfig: Record<string, any>) {
     ready: false,
     dev: false,
 
-
     overrides: {
       buildDir: '.nuxt-storybook',
     },
@@ -90,7 +89,9 @@ async function defineNuxtConfig(baseConfig: Record<string, any>) {
         { isClient }: any,
       ) => {
         if (isClient) {
-          const plugins = baseConfig.plugins
+          extendedConfig = mergeConfig(config, baseConfig)
+
+          const plugins = extendedConfig.plugins || []
 
           // Find the index of the plugin with name 'vite:vue'
           const index = plugins.findIndex((plugin: any) => plugin.name === 'vite:vue')
@@ -101,10 +102,10 @@ async function defineNuxtConfig(baseConfig: Record<string, any>) {
             plugins[index] = vuePlugin()
           }
           else {
-            plugins.push(vuePlugin())
+            plugins.unshift(vuePlugin())
           }
-          baseConfig.plugins = plugins
-          extendedConfig = mergeConfig(config, baseConfig)
+
+          extendedConfig.plugins = plugins
         }
       },
     )


### PR DESCRIPTION
`@vitejs/plugin-vue` should be the first registered user plugin so that it will be added directly after Vite's core plugins and transforms global vue compoments before nuxt:components:imports. The transform stack order can be reviewed with the `vite-plugin-inspect` plugin.

This fixes the use of global components in projects or modules.

Refs: #4